### PR TITLE
Replace remaining references to text window

### DIFF
--- a/2d.pl
+++ b/2d.pl
@@ -250,7 +250,7 @@ sharp corners where the entities intersect.
 <p>
 To round these, we will use the "Tangent Arc" tool. We can start by
 setting up some parameters of that tool. So with nothing selected, choose
-Sketch &rarr; Tangent Arc at Point. In the text window, we see that by
+Sketch &rarr; Tangent Arc at Point. In the Property Browser, we see that by
 default, the radius of this arc will be chosen automatically. This is not
 what we want, so we left-click to un-check that box. We now can enter
 our desired radius, which for the outer contour is 0.200 inches. (It
@@ -307,7 +307,7 @@ it will use the same radius as before. This completes the outer contour:
 <p>
 For the inner contour, we wish to use a different radius: 0.050 inch
 (or the diameter of 0.100/2). So we choose Sketch &rarr; Tangent Arc at
-Point with nothing selected, to view the screen in the text window again.
+Point with nothing selected, to view the screen in the Property Browser again.
 We enter our new radius of 0.050 inches, and leave the other settings
 unchanged. We then select one of the points to be rounded, and choose
 Sketch &rarr; Tangent Arc at Point.
@@ -319,7 +319,7 @@ Sketch &rarr; Tangent Arc at Point.
 
 <p>
 Note that points are hidden in the above image, by clicking the
-appropriate icon in the strip at the top of the text window. The points
+appropriate icon in the strip at the top of the Property Browser. The points
 would otherwise clutter the view, and obscure the small arc.
 </p>
 
@@ -339,7 +339,7 @@ We then left-click once on the drawing, to define the top left point of the
 text, and click again to define the bottom left. By default, the text will
 consist of the letters "Abc", and the font will be Arial. To change these,
 we left-click the text to select it. A description of the text appears in
-the text window, along with a list of available fonts. (Any TrueType font
+the Property Browser, along with a list of available fonts. (Any TrueType font
 installed through Windows will be available here; the exact list will
 vary with what programs and special fonts you have chosen to install.)
 To select a font, click it in that list.
@@ -350,7 +350,7 @@ To select a font, click it in that list.
 </div>
 
 <p>
-Then to change the text, we scroll to the top of the text window. The
+Then to change the text, we scroll to the top of the Property Browser. The
 current text ("Abc") is listed, and a link next to that text permits us
 to change the text. We click that link, type the new string in the text
 box, and hit Enter to confirm. The text will change, both in the text
@@ -412,7 +412,7 @@ now), or to create a new custom style.
 <p>
 We choose the latter. Initially, nothing changes, since the new custom
 style is created with the same line width and color as the default style.
-But in the text window, we see a description of our new style, which
+But in the Property Browser, we see a description of our new style, which
 we can edit according to our preference. First, we should name the
 style something meaningful, by clicking the "rename" link at the top of
 the page.  We might, for example, choose to name it "blue-text". We then
@@ -474,7 +474,7 @@ If we wanted to change something about the styles&mdash;for example, if we
 wanted to change the color of the contour from white to green&mdash;then
 we could go back to the list of styles, and edit the appropriate style
 (in this case, s101-fat-contour) accordingly. From the home screen of
-the text window (click the link at the top left of the window, or press
+the Property Browser (click the link at the top left of the window, or press
 Esc a few times), we choose the "line styles" link at the bottom of the
 page. We now see a list of all the styles. The list is long, because it
 includes all the default styles:
@@ -598,7 +598,7 @@ have chosen something else.
 
 <p>
 This creates a new group. If we return to the home screen in the
-text window (by clicking the link at the top left, or pressing Esc a
+Property Browser (by clicking the link at the top left, or pressing Esc a
 few times), then we see that there are now two sketch groups in our
 file: g002-..., which contains the lines and curves that we've drawn,
 and g003-..., which is the new empty group we've just created for our
@@ -620,7 +620,7 @@ could mark each dimension individually as a reference dimension, but
 that would be tedious (and they would all appear with "REF" next to the
 number, which is not what we want). So we wish to make all dimensions
 in this group behave as reference dimensions. We can do that by viewing
-the group's screen in the text window, by clicking its name in the list.
+the group's screen in the Property Browser, by clicking its name in the list.
 </p>
 
 <p>

--- a/box.pl
+++ b/box.pl
@@ -159,12 +159,12 @@ TEMPL::OutputWithHeader("TUTORIAL: ASSEMBLIES", <<EOT
 </div>
 <p>
     Note that we have now hidden points and normals, by clicking the
-    respective icons at the top of the text window. The assembly is getting
+    respective icons at the top of the Property Browser. The assembly is getting
     more complex, so those were cluttering the screen. We can show or hide
     those as desired at any time.
 </p>
 <p>
-    In the step and repeat group's text window screen (press Tab to show
+    In the step and repeat group's Property Browser screen (press Tab to show
     that window if it is hidden), we can change the number of times repeated
     to seven. We now see seven copies of that divider. We can drag these
     copies with the mouse. The first one is locked, and the orientation of
@@ -316,9 +316,9 @@ TEMPL::OutputWithHeader("TUTORIAL: ASSEMBLIES", <<EOT
     The assembly is now complete. We can view it on-screen, and produce
     isometric (View &rarr; Nearest Isometric View) or top, bottom and side
     (View &rarr; Nearest Ortho View) views of all the parts. We can suppress
-    the display of a part by changing that setting in its text window screen.
+    the display of a part by changing that setting in its Property Browser screen.
     For example, to hide the base, we would click the home link at the
-    top of the text window, and then choose its group&mdash;which in our
+    top of the Property Browser, and then choose its group&mdash;which in our
     assembly was the first import group, g003-import&mdash;from the list of
     groups. We then click the box labeled "suppress this group's solid model"
     to check it. To show that part again, we click that box again to uncheck
@@ -357,7 +357,7 @@ TEMPL::OutputWithHeader("TUTORIAL: ASSEMBLIES", <<EOT
     View &rarr; Use Perspective Projection. To adjust the amount of
     perspective, change the perspective factor in the configuration
     screen. The configuration screen is reachable from the link at the
-    bottom of the home screen in the text window.)
+    bottom of the home screen in the Property Browser.)
 </p>
 <p>
     We can make changes to one of the parts, and then regenerate the

--- a/constraints.pl
+++ b/constraints.pl
@@ -62,7 +62,7 @@ sketch accordingly.
 
 <p>
 This constraint removes one DOF, so the sketch now has five DOF. To
-confirm this, go to the home screen in the text window (by pressing Esc,
+confirm this, go to the home screen in the Property Browser (by pressing Esc,
 or clicking the home link at the top left), and select the sketch,
 probably g002-sketch-in-plane, from the list. A list of constraints
 appears, and the number of degrees of freedom is indicated.
@@ -94,7 +94,7 @@ triangle should have three DOF, and it does.
 We could attempt to constrain the length of another side of the triangle,
 again by choosing Constrain &rarr; Distance. If we do so, then we see
 that the background of the sketch turns red, to indicate an error. In the
-text window, we are informed that the solver has failed. This is because
+Property Browser, we are informed that the solver has failed. This is because
 we have attempted to overconstrain the sketch. We had already specified
 enough constraints to exactly describe our triangle. This means that
 any additional constraints are not useful&mdash;either they are redundant,

--- a/ref.pl
+++ b/ref.pl
@@ -20,7 +20,7 @@ General Navigation</h2>
     The user interface consists of two windows: a larger window that
     contains mostly graphics, and a smaller window that contains mostly
     text. The graphics window is used to draw the geometry, and to view
-    the 3d model. The text window provides information about the model,
+    the 3d model. The Property Browser provides information about the model,
     and may also be used to modify settings and numerical parameters.
 </p>
 
@@ -126,14 +126,14 @@ Dimension Entry and Units</h3>
 Text Window</h3>
 
 <p>
-    The text window appears as a floating palette window. It may
+    The Property Browser appears as a floating palette window. It may
     be shown or hidden by pressing Tab, or by choosing View &rarr;
     Show Text Window.
 
 <p>
-    The text window works like a web browser. Any underlined text is
+    The Property Browser works like a web browser. Any underlined text is
     a link. To activate a link, click it with the mouse. The links
-    may be used to navigate to other pages in the text window. For
+    may be used to navigate to other pages in the Property Browser. For
     example, the "home" screen is a list of groups in the sketch:
 
 <div class="forimg">
@@ -148,9 +148,9 @@ Text Window</h3>
     "shown" column.
 
 <p>
-    As a convenience, the text window will sometimes automatically
+    As a convenience, the Property Browser will sometimes automatically
     navigate to a page that is likely to be relevant. For example,
-    when a new group is created, the text window displays that new
+    when a new group is created, the Property Browser displays that new
     group's page. It's always possible to navigate to a different
     page, by clicking the "home" link at the top left corner (or
     pressing Esc), and following the links from there.
@@ -158,12 +158,12 @@ Text Window</h3>
 <p>
     When sketch entities are selected (e.g., the user has clicked
     on them with the mouse), information about those entities is
-    displayed in the text window. If a single entity is selected,
+    displayed in the Property Browser. If a single entity is selected,
     then information about that entity is displayed. For example,
     the window display's a circle's center and radius.
 
 <p>
-    If multiple entities are selected, then the text window can
+    If multiple entities are selected, then the Property Browser can
     sometimes display information about all of them. These cases
     include:
 
@@ -190,7 +190,7 @@ Show / Hide Entities</h3>
 </p>
 
 <p>
-    Along the top of the text window, a row of icons appears. These icons
+    Along the top of the Property Browser, a row of icons appears. These icons
     make it possible to hide and show different elements in the sketch:
 </p>
 
@@ -302,7 +302,7 @@ is useful when drawing a sketch that lies within the volume of the part.
         cylinder will remain visible.
 
 <p>
-        To hide a group, go to the home screen in the text window, by
+        To hide a group, go to the home screen in the Property Browser, by
         pressing Esc or choosing the link at the top left. A list of
         groups is displayed, along with their visibility. If a group
         is visible, then the checkbox in the "shown" column is checked.
@@ -326,7 +326,7 @@ Active Workplane</h3>
     it possible to draw in a plane. If a workplane is active, then
     all entities that are drawn will be forced to lie that plane.
     The active workplane ("in plane:") is indicated in the top line of
-    the text window, at the right.
+    the Property Browser, at the right.
 
 <p>
     When SolveSpace starts with a new empty file, a workplane parallel
@@ -357,7 +357,7 @@ Active Group</h3>
     are hidden.
 
 <p>
-    In the text window's home screen (press Escape, or choose the link
+    In the Property Browser's home screen (press Escape, or choose the link
     in the top left corner), the active group's line in the list of
     groups has a selected radio button in the "active" column. All
     other groups (except g001-#references, which cannot be activated)
@@ -558,7 +558,7 @@ Tangent Arc at Point</h3>
 <p>
     By default, the radius of the tangent arc is chosen automatically.
     To change that, choose Sketch &rarr; Tangent Arc at Point with nothing
-    selected. A screen will appear in the text window, where the radius
+    selected. A screen will appear in the Property Browser, where the radius
     may be specified. It is also possible to specify whether the original
     lines and curves should be kept, but changed to construction lines
     (which may be useful if you want to place constraints on them),
@@ -617,9 +617,9 @@ Text in a TrueType Font</h3>
 
 <p>
     To change the font, select the text entity. A list of installed
-    fonts appears in the text window; click the font name to select
+    fonts appears in the Property Browser; click the font name to select
     it. To change the displayed text, select the text entity and
-    click the [change] link in the text window.
+    click the [change] link in the Property Browser.
 
 <h3><a id="Image" href="#Image" class="anchor"></a>
 Image</h3>
@@ -787,7 +787,7 @@ Failure to Solve</h3>
 <p>
     If the sketch is inconsistent or redundant, then the background
     of the graphics window is drawn in red (instead of the usual
-    black), and an error is displayed in the text window:
+    black), and an error is displayed in the Property Browser:
 
 <div class="forimg">
     <img src="pics/ref-inconsistent.png">
@@ -797,7 +797,7 @@ Failure to Solve</h3>
     As a convenience, SolveSpace calculates a list of constraints
     that could be removed to make the sketch consistent again. To
     see which constraints those are, hover the mouse over the links
-    in the text window; the constraint will appear highlighted in
+    in the Property Browser; the constraint will appear highlighted in
     the graphics window. By deleting one or more of the constraints
     in that list, the user can make the sketch consistent again.
 
@@ -1165,7 +1165,7 @@ Groups</h2>
 
 <div class="refind">
 <p>
-    To view a list of groups, go to the home page of the text window.
+    To view a list of groups, go to the home page of the Property Browser.
     This is accessible from the link at the top left of the text
     window, or by pressing Esc. To view a group's page, click
     its name in the list.
@@ -1173,12 +1173,12 @@ Groups</h2>
 <p>
     All groups have a name. When the group is created, a default name
     (e.g., "g008-extrude") is assigned. The user may change this name;
-    to do so, go to the group's page in the text window, and choose
+    to do so, go to the group's page in the Property Browser, and choose
     [rename].
 
 <p>
     Groups that create a solid (e.g. extrudes or lathes) have a "solid
-    model as" option, which is displayed in the page in the text window.
+    model as" option, which is displayed in the page in the Property Browser.
     The group can be merged as union, which adds material to the
     model, or as difference, which cuts material away. A third option is
     intersection, which preserves only the material that falls within
@@ -1197,14 +1197,14 @@ Groups</h2>
 <p>
     These groups also have a color, which determines the color of
     the surfaces they produce. To change the color, click one of
-    the swatches in the group's page in the text window.
+    the swatches in the group's page in the Property Browser.
 
 <p>
-    The group's page in the text window also includes a list of all
+    The group's page in the Property Browser also includes a list of all
     requests, and of all constraints. To identify a constraint or a
     request, hover the mouse over its name; it will appear highlighted
     in the graphics window. To select it, click the link in the
-    text window. This is equivalent to hovering over and clicking
+    Property Browser. This is equivalent to hovering over and clicking
     the actual object in the graphics window.
 
 <h3><a id="SketchIn3d" href="#SketchIn3d" class="anchor"></a>
@@ -1294,7 +1294,7 @@ Step Translating</h3>
 <p>
     The number of copies to create is specified by the user. To
     change this value, click the [change] link in the group's page
-    in the text window.
+    in the Property Browser.
 
 <p>
     The copies may be translated on one side, or on two sides. If
@@ -1573,7 +1573,7 @@ appears on-screen and in an exported file.
 
 <p>
 SolveSpace's basic color scheme is defined by the default styles. To view
-them, choose "line styles" from the home screen in the text window. This
+them, choose "line styles" from the home screen in the Property Browser. This
 is where, for example, lines are specified to be white by default, and
 constraints to be magenta, and points to be green. The default styles may
 be modified. These modifications will be saved in the user config (the
@@ -1600,7 +1600,7 @@ thicker compared to the model in the exported file.</p>
 <p>Entities (like lines, circles, or arcs) may be assigned to a line style.
 One way to do so is to enter the desired line style's screen in the text
 window, and then select the desired entities. Then click the "assign to
-style" link in the text window. Another way to do so is to right-click
+style" link in the Property Browser. Another way to do so is to right-click
 the entity, and assign it to the style using the context menu.</p>
 
 <p>Comments (Constrain &rarr; Comment) may also be assigned to styles. The
@@ -1791,7 +1791,7 @@ Bitmap Image</h3>
     <td class="showright"><p>
         Any surfaces coplanar with that plane face will appear in the
         file. The faces must be shown before they can be selected;
-        click the link in the third line of the text window.
+        click the link in the third line of the Property Browser.
     </p></td>
 
     </tr><tr>
@@ -1958,7 +1958,7 @@ Configuration</h2>
 Material Colors</h3>
 
 <p>
-    In the text window screen for certain groups (extrude, lathe,
+    In the Property Browser screen for certain groups (extrude, lathe,
     sweep), a palette of eight colors is displayed. This palette
     allows the user to choose the color of any surfaces generated
     by that group.


### PR DESCRIPTION
A follow up of textual changes in 6d1b1ecb1602a4db675b94cbe33be0b3d50fbdbb, as not everything was replaced. The capitalisation used in that commit was used. I like the new name, it's much clearer.

It doesn't seem like 6d1b1ecb1602a4db675b94cbe33be0b3d50fbdbb (or the subsequent fix to a branch link) was deployed, I noticed references to "text window" when following [the bracket tutorial](https://solvespace.com/bracket.pl) this weekend.